### PR TITLE
Prevent stack overflow with current Jenkins version (1.570)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/youtrack/YouTrackSCMListener.java
+++ b/src/main/java/org/jenkinsci/plugins/youtrack/YouTrackSCMListener.java
@@ -33,7 +33,6 @@ public class YouTrackSCMListener extends SCMListener {
             }
             performActions(build, listener, youTrackSite, changeLogIterator, youTrackServer, user);
         }
-        super.onChangeLogParsed(build, listener, changeLogSet);
     }
 
     protected void performActions(AbstractBuild<?, ?> build, BuildListener listener, YouTrackSite youTrackSite, Iterator<? extends ChangeLogSet.Entry> changeLogIterator, YouTrackServer youTrackServer, User user) throws IllegalAccessException, InvocationTargetException {


### PR DESCRIPTION
When trying to run the current version of the plugin (0.5.3) with our version of Jenkins (1.570), a stack overflow appears when building a project with YouTrack annotations enabled. The stacktrace mostly consists of the following 3 invocations:

at org.jenkinsci.plugins.youtrack.YouTrackSCMListener.onChangeLogParsed(YouTrackSCMListener.java:36)
at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:113)
at hudson.model.listeners.SCMListener.onChangeLogParsed(SCMListener.java:119)

This is because of a recent commit in Jenkins: https://github.com/jenkinsci/jenkins/commit/5b6522808090ae675826a6033382f2361f7f270c

It's arguable whether the double fallback in that commit is really a good idea. However there's an easy way to fix in youtrack-plugin by just not calling super. The super method was empty before the commit mentioned above anyways, so that call shouldn't be necessary.

Alas I have no easy way to test my change, but I'm quite confident that it will fix the stack overflow.
