### PR TITLE
Don't apply empty primary command

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/youtrack/YoutrackIssueUpdater.java
+++ b/src/main/java/org/jenkinsci/plugins/youtrack/YoutrackIssueUpdater.java
@@ -335,7 +335,10 @@ public class YoutrackIssueUpdater {
                     if (extraPrefixCommand != null) {
                         applyCommandToIssue(build, youTrackSite, youTrackServer, user, fixedIssues, changeLogEntry, issueAndCommand.getFirst(), extraPrefixCommand, null, listener, commands, isSilent);
                     }
-                    applyCommandToIssue(build, youTrackSite, youTrackServer, user, fixedIssues, changeLogEntry, issueAndCommand.getFirst(), issueAndCommand.getSecond(), comment, listener, commands, isSilent);
+
+                    if (issueAndCommand.getSecond() != null && !issueAndCommand.getSecond().equals("")) {
+                        applyCommandToIssue(build, youTrackSite, youTrackServer, user, fixedIssues, changeLogEntry, issueAndCommand.getFirst(), issueAndCommand.getSecond(), comment, listener, commands, isSilent);
+                    }
                 }
             }
         }

--- a/src/test/java/org/jenkinsci/plugins/youtrack/YouTrackSCMListenerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/youtrack/YouTrackSCMListenerTest.java
@@ -277,16 +277,7 @@ public class YouTrackSCMListenerTest {
         command1.setIssueId("TP1-1");
         command1.setStatus(Command.Status.OK);
         command1.setUsername(user.getUsername());
-        Command command2 = new Command();
-        command2.setDate(new Date());
-        command2.setComment(partialSecondComment);
-        command2.setCommand("Fixed");
-        command2.setSilent(false);
-        command2.setIssueId("TP1-1");
-        command2.setStatus(Command.Status.OK);
-        command2.setUsername(user.getUsername());
         when(youTrackServer.applyCommand("testsite", user, new Issue("TP1-1"), "Fixed", partialFirstComment, null, null, true)).thenReturn(command1);
-        when(youTrackServer.applyCommand("testsite", user, new Issue("TP1-2"), "", partialSecondComment, null, null, true)).thenReturn(command2);
 
         ArrayList<Project> projects = new ArrayList<Project>();
         Project project1 = new Project();
@@ -315,7 +306,7 @@ public class YouTrackSCMListenerTest {
 
         YouTrackCommandAction youTrackCommandAction = freeStyleBuild.getAction(YouTrackCommandAction.class);
         List<Command> commands = youTrackCommandAction.getCommands();
-        assertEquals(2, commands.size());
+        assertEquals(1, commands.size());
     }
 
     @Test


### PR DESCRIPTION
In current version empty primary command is applied to project in YouTrack
when prefix command is used if string looks like "Fixed #PROJECT-<NUM>".