### PR TITLE
Empty `buildUpdateCommand` should be treated as default one

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/youtrack/YouTrackBuildUpdater.java
+++ b/src/main/java/org/jenkinsci/plugins/youtrack/YouTrackBuildUpdater.java
@@ -41,7 +41,7 @@ public class YouTrackBuildUpdater extends Recorder {
     @Getter @Setter private boolean markFixedIfUnstable;
     @Getter @Setter private boolean onlyAddIfHasFixedIssues;
     @Getter @Setter private boolean runSilently;
-    @Getter @Setter private String buildUpdateCommand;
+    @Setter private String buildUpdateCommand;
 
     @DataBoundConstructor
     public YouTrackBuildUpdater(String name, String bundleName, String buildName, boolean markFixedIfUnstable, boolean onlyAddIfHasFixedIssues, boolean runSilently, String buildUpdateCommand) {
@@ -53,7 +53,7 @@ public class YouTrackBuildUpdater extends Recorder {
         this.onlyAddIfHasFixedIssues = onlyAddIfHasFixedIssues;
         this.runSilently = runSilently;
         this.buildUpdateCommand = buildUpdateCommand;
-        if (buildUpdateCommand == null) {
+        if (buildUpdateCommand == null || buildUpdateCommand.equals("")) {
             this.buildUpdateCommand = "Fixed in build: ${YOUTRACK_BUILD_NAME}";
         }
     }
@@ -73,6 +73,13 @@ public class YouTrackBuildUpdater extends Recorder {
             this.buildName = "${BUILD_NUMBER} ("+name+")";
         }
         return buildName;
+    }
+    
+    public String getBuildUpdateCommand() {
+        if (buildUpdateCommand == null || buildUpdateCommand.equals("")) {
+            this.buildUpdateCommand = "Fixed in build: ${YOUTRACK_BUILD_NAME}";
+        }
+        return buildUpdateCommand;
     }
 
     public BuildStepMonitor getRequiredMonitorService() {


### PR DESCRIPTION
Currently empty `buildUpdateCommand` in project's post-build action leads either to:
- NPE at line 150 (before the patch) because commandValue is `null` (if post-build action was present before update to v0.6.6);
- sending empty update command to youtrack, so build is added to the builds bundle but issue's fixed in build does not change (if post-build action is created/recreated for the project).